### PR TITLE
Fix HTTP method when calling functions

### DIFF
--- a/odata4j-core/src/main/java/org/odata4j/consumer/AbstractConsumerQueryRequestBase.java
+++ b/odata4j-core/src/main/java/org/odata4j/consumer/AbstractConsumerQueryRequestBase.java
@@ -66,13 +66,16 @@ public abstract class AbstractConsumerQueryRequestBase<T> implements OQueryReque
     return metadata;
   }
 
-  protected ODataClientRequest buildRequest(Func1<String, String> pathModification) {
+  protected ODataClientRequest buildRequest(String method,
+          Func1<String, String> pathModification) {
+
     String path = Enumerable.create(segments).join("/");
     path += (path.length() == 0 ? "" : "/") + lastSegment;
     if (pathModification != null)
       path = pathModification.apply(path);
 
-    ODataClientRequest request = ODataClientRequest.get(serviceRootUri + path);
+    ODataClientRequest request = new ODataClientRequest(method,
+            serviceRootUri + path, null, null, null);
 
     if (top != null) {
       request = request.queryParam("$top", Integer.toString(top));
@@ -97,6 +100,10 @@ public abstract class AbstractConsumerQueryRequestBase<T> implements OQueryReque
     }
 
     return request;
+  }
+
+  protected ODataClientRequest buildRequest(Func1<String, String> pathModification) {
+      return buildRequest("GET", pathModification);
   }
 
   @Override

--- a/odata4j-core/src/main/java/org/odata4j/consumer/ConsumerFunctionCallRequest.java
+++ b/odata4j-core/src/main/java/org/odata4j/consumer/ConsumerFunctionCallRequest.java
@@ -61,7 +61,8 @@ public class ConsumerFunctionCallRequest<T extends OObject>
     for (OFunctionParameter p : params)
       custom(p.getName(), toUriString(p));
 
-    final ODataClientRequest request = buildRequest(null);
+    final ODataClientRequest request = buildRequest(function.getHttpMethod(), null);
+
     Enumerable<OObject> results;
     if (function.getReturnType() == null) {
       results = Enumerable.empty(null);


### PR DESCRIPTION
The HTTP method was hardcoded to GET when calling service funtions. As
the correct method is available in the function metadata it is quite
esay to ensure that the correct method is called.
