### PR TITLE
Fixes for JPA embeddables (issue 85),  enums (issue 133) and $expand (issue 219)

### DIFF
--- a/odata4j-core/src/main/java/org/odata4j/core/OSimpleObjects.java
+++ b/odata4j-core/src/main/java/org/odata4j/core/OSimpleObjects.java
@@ -24,11 +24,7 @@ public class OSimpleObjects {
     if (type == EdmSimpleType.STRING) {
       String sValue = null;
       if (value != null) {
-        if (value instanceof Character) {
-          sValue = value.toString();
-        } else {
-          sValue = (String) value;
-        }
+        sValue = value.toString();
       }
       return (OSimpleObject<T>) Impl.create(EdmSimpleType.STRING, sValue);
     } else if (type == EdmSimpleType.BOOLEAN) {

--- a/odata4j-core/src/main/java/org/odata4j/edm/EdmComplexType.java
+++ b/odata4j-core/src/main/java/org/odata4j/edm/EdmComplexType.java
@@ -32,7 +32,7 @@ public class EdmComplexType extends EdmStructuralType {
   }
 
   static Builder newBuilder(EdmComplexType complexType, BuilderContext context) {
-    return context.newBuilder(complexType, new Builder());
+    return context.newBuilder(complexType, new Builder().newBuilder(complexType, context)); // Fill properties.
   }
 
   /** Mutable builder for {@link EdmComplexType} objects. */

--- a/odata4j-core/src/main/java/org/odata4j/internal/TypeConverter.java
+++ b/odata4j-core/src/main/java/org/odata4j/internal/TypeConverter.java
@@ -100,8 +100,23 @@ public class TypeConverter {
 
     if (desiredClass.equals(UUID.class) && (objClass.equals(Guid.class) || objClass.equals(String.class)))
       return (T) UUID.fromString(obj.toString());
+    
+    // enum conversions
+    if (desiredClass.isEnum() && obj instanceof String) 
+      return (T)getEnumValue(desiredClass, obj.toString());
 
     throw new UnsupportedOperationException(String.format("Unable to convert %s into %s", objClass.getName(), desiredClass.getName()));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <E extends Enum<E>> Enum<E> getEnumValue(Class<?> enumClass, String enumMemberName)
+  {
+    try {
+      return Enum.valueOf((Class<E>)enumClass, enumMemberName);
+    }
+    catch (IllegalArgumentException ex) {
+      throw new UnsupportedOperationException(String.format("The enum %s does not contain a literal %s", enumClass.getName(), enumMemberName));
+    }
   }
 
   private static Date getDateFromLocalDateTime(Object obj) {

--- a/odata4j-core/src/main/java/org/odata4j/producer/jpa/ExecuteJPQLQueryCommand.java
+++ b/odata4j-core/src/main/java/org/odata4j/producer/jpa/ExecuteJPQLQueryCommand.java
@@ -3,6 +3,7 @@ package org.odata4j.producer.jpa;
 import java.util.Collections;
 import java.util.List;
 
+import javax.persistence.EntityNotFoundException;
 import javax.persistence.Query;
 
 import org.odata4j.edm.EdmMultiplicity;
@@ -101,10 +102,14 @@ public class ExecuteJPQLQueryCommand implements Command {
           .getEdmPropertyBase();
       if (edmNavProp.getToRole().getMultiplicity() == EdmMultiplicity.ONE
           || edmNavProp.getToRole().getMultiplicity() == EdmMultiplicity.ZERO_TO_ONE) {
-        if (results.size() != 1)
+        
+      	if (results.size() > 1)
           throw new RuntimeException(
               "Expected only one entity, found "
                   + results.size());
+      	
+      	if (results.size() == 0)
+      		throw new EntityNotFoundException("Resource not found");
 
         return JPAResults.entity(results.get(0));
       }

--- a/odata4j-core/src/main/java/org/odata4j/producer/jpa/ExpectSingleEntityCommand.java
+++ b/odata4j-core/src/main/java/org/odata4j/producer/jpa/ExpectSingleEntityCommand.java
@@ -1,0 +1,32 @@
+package org.odata4j.producer.jpa;
+
+import javax.persistence.metamodel.EntityType;
+
+import org.odata4j.exceptions.NotFoundException;
+
+public class ExpectSingleEntityCommand implements Command {
+
+  @Override
+  public boolean execute(JPAContext context)
+  {
+    EntitiesResult entitiesResult = (EntitiesResult)context.getResult();
+    
+    if (entitiesResult.getEntities().size() == 0) {
+      EntityType<?> jpaEntityType = context.getEntity()
+        .getJPAEntityType();
+      
+      Object typeSafeEntityKey = context.getEntity()
+        .getTypeSafeEntityKey();
+      
+      throw new NotFoundException(jpaEntityType
+          .getJavaType()
+          + " not found with key "
+          + typeSafeEntityKey);
+    }
+    
+    context.setResult(JPAResults.entity(entitiesResult.getEntities().get(0)));
+    
+    return false;
+  }
+
+}

--- a/odata4j-core/src/main/java/org/odata4j/producer/jpa/JPAEdmGenerator.java
+++ b/odata4j-core/src/main/java/org/odata4j/producer/jpa/JPAEdmGenerator.java
@@ -267,7 +267,29 @@ public class JPAEdmGenerator implements EdmGenerator {
       // namespace.name.  (multiple Entity classes may have properties of this
       // type and we don't wan't lots of instances of EdmComplex type floating
       // around that are the same conceptual type)
-      type = EdmComplexType.newBuilder().setNamespace(modelNamespace).setName(simpleName).build();
+
+      // Enumeration of sub-properties start.
+      
+      EdmComplexType.Builder builder = EdmComplexType.newBuilder().setNamespace(modelNamespace).setName(simpleName);
+      
+      EmbeddableType<?> embeddableType = (EmbeddableType<?>)sa.getType();
+      
+      List<EdmProperty.Builder> embeddedPropertyBuilders = new ArrayList<EdmProperty.Builder>(embeddableType.getSingularAttributes().size());
+      
+      for (SingularAttribute<?, ?> embeddedAttribute : embeddableType.getDeclaredSingularAttributes())
+      {
+      	if (embeddedAttribute.getPersistentAttributeType() == PersistentAttributeType.BASIC)
+      	{
+      		embeddedPropertyBuilders.add(toEdmProperty(modelNamespace, embeddedAttribute));
+      	}
+      }
+      
+      builder.addProperties(embeddedPropertyBuilders);
+      
+      type = builder.build();
+      
+      // Enumeration of sub-properties end.
+      
     } else if (sa.getBindableJavaType().isEnum()) {
       // TODO assume string mapping for now, @Enumerated info not avail in metamodel?
       type = EdmSimpleType.STRING;

--- a/odata4j-core/src/main/java/org/odata4j/producer/jpa/JPAProducer.java
+++ b/odata4j-core/src/main/java/org/odata4j/producer/jpa/JPAProducer.java
@@ -176,8 +176,22 @@ public class JPAProducer implements ODataProducer {
     commands = new ArrayList<Command>();
     // create an EntityManager
     commands.add(new EntityManagerCommand(emf));
-    // get the requested JPAEntity
-    commands.add(new GetEntityCommand());
+    /* Fix for $expand support: GetEntityCommand duplicates functionality of 
+     * GenerateJPQLCommand and ExecuteJPQLQueryCommand, and it bears the same $expand bug. 
+     * As the fix is already specified in the latter two, we divert execution to these. */ 
+
+    /* We remove the following command. */ 
+//    // get the requested JPAEntity
+//    commands.add(new GetEntityCommand());
+
+    /* We use these commands instead. */
+    // parse generate the JPQL query
+    commands.add(new GenerateJPQLCommand());
+    // execute the JPQL query
+    commands.add(new ExecuteJPQLQueryCommand(1 /* maxResults is 1, we specify one entity. */));
+    // convert to single entity output.
+    commands.add(new ExpectSingleEntityCommand());
+    
     // convert the JPAEntity to OEntity and set the response
     commands.add(new SetResponseCommand());
     getEntityCommand = createChain(CommandType.GetEntity, commands);


### PR DESCRIPTION
Issue 85: Provide support for @Embeddable/@Embedded attributes for non-key types.

Issue 133: JPAProducer: enums not suported.
Enums are given as strings, just as the metadata already describe them in the original code before this fork. Tested in both reading and writing scenarios.

Issue 219: $expand broke in version 0.7 with JPAProducer.
Version 0.6 worked, but it filled the relationships using lazy loading, resulting in many database roundtrips and big performance degradation. This proposed implementation not only reenables the feature but it also creates JPA queries which fetch the expanded relationships eagerly in a single roundtrip.
